### PR TITLE
Add claude-skills to the collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection) | ![GitHub Repo stars](https://badgen.net/github/stars/davepoon/claude-code-subagents-collection) | Claude Code Subagents & Commands Collection + CLI Tool | Subagents CLI tool|
 |[awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/vijaythecoder/awesome-claude-agents) | Orchestrated sub agent dev team powered by claude code | Sub agent dev team|
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
+|[claude-skills](https://github.com/alirezarezvani/claude-skills) | ![GitHub Repo stars](https://badgen.net/github/stars/alirezarezvani/claude-skills) | 177 skill packages across engineering, marketing, product, compliance, and advisory. Includes 16 agents, 17 commands, and Python tools. Supports 11 AI coding tools. | Skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
 


### PR DESCRIPTION
Adds claude-skills to the Framework Extensions section.

177 skill packages across engineering, marketing, product, compliance, and advisory domains. Each skill includes structured instructions (SKILL.md), and many include Python automation tools and reference documents. Also ships 16 agents and 17 slash commands. Supports Claude Code and 10 other AI coding tools.

https://github.com/alirezarezvani/claude-skills