### PR TITLE
Add china-mcp-servers to MCP Servers & Plugins

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -140,6 +140,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Claude Code 的简化 Gemini | Gemini 集成|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | 为 Claude Code 带来 Gemini AI 功能的轻量级 MCP 集成 | 轻量级 Gemini 集成|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | Claude Code 的 MCP Gemini 编程助手 | Gemini 编程助手|
+|[china-mcp-servers](https://github.com/huanglei288766/china-mcp-servers) | ![GitHub Repo stars](https://badgen.net/github/stars/huanglei288766/china-mcp-servers) | 中国主流办公平台 MCP 合集（飞书、钉钉）— 消息、文档、日历、任务、审批 | 中国服务 MCP|
 
 ## 指南与文档
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ English | [简体中文](README-CN.md)
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
+|[china-mcp-servers](https://github.com/huanglei288766/china-mcp-servers) | ![GitHub Repo stars](https://badgen.net/github/stars/huanglei288766/china-mcp-servers) | MCP servers for Chinese workplace platforms (Feishu/Lark and DingTalk) - messaging, docs, calendar, tasks, approvals | China services MCP|
 
 ## Guides & Documentation
 


### PR DESCRIPTION
## Summary

Adds [china-mcp-servers](https://github.com/huanglei288766/china-mcp-servers) to the **MCP Servers & Plugins** section.

A collection of MCP servers for China's mainstream workplace platforms:

- **Feishu (Lark)**: Send messages, create docs, manage calendars, create tasks
- **DingTalk**: Webhook/work notifications, approvals, calendar management

Install via `npx @china-mcp/feishu-mcp` or `npx @china-mcp/dingtalk-mcp`.

## Changes

- Added entry to MCP Servers & Plugins table in `README.md`
- Added entry to MCP服务器与插件 table in `README-CN.md`