### PR TITLE
Add antigravity-awesome-skills to Framework Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection) | ![GitHub Repo stars](https://badgen.net/github/stars/davepoon/claude-code-subagents-collection) | Claude Code Subagents & Commands Collection + CLI Tool | Subagents CLI tool|
 |[awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/vijaythecoder/awesome-claude-agents) | Orchestrated sub agent dev team powered by claude code | Sub agent dev team|
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
+|[antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills) | ![GitHub Repo stars](https://badgen.net/github/stars/sickn33/antigravity-awesome-skills) | Large, curated collection of reusable `SKILL.md` packages for Claude Code, Codex CLI, Gemini CLI, and other AI coding agents. | Multi-agent skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
 


### PR DESCRIPTION
Add [antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills) to the Framework Extensions section as a multi-agent skills library.

Why:
- It provides a large curated set of reusable SKILL.md packages for Claude Code and related coding agents.
- It complements existing entries such as superpowers and agent-focused repositories.

I kept the existing table format and star badge style for consistency.