### PR TITLE
Add Claude Code AWS Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-openai-wrapper](https://github.com/RichardAtCT/claude-code-openai-wrapper) | ![GitHub Repo stars](https://badgen.net/github/stars/RichardAtCT/claude-code-openai-wrapper) | OpenAI API-compatible wrapper for Claude Code | OpenAI compatible wrapper|
 |[anyclaude](https://github.com/coder/anyclaude) | ![GitHub Repo stars](https://badgen.net/github/stars/coder/anyclaude) | Claude Code with any LLM | Multi-model support|
 |[claude-code-open](https://github.com/Davincible/claude-code-open) | ![GitHub Repo stars](https://badgen.net/github/stars/Davincible/claude-code-open) | Claude Code with any LLM provider | Open LLM support|
+|[claude-code-aws-gateway](https://github.com/antkawam/claude-code-aws-gateway) | ![GitHub Repo stars](https://badgen.net/github/stars/antkawam/claude-code-aws-gateway) | Self-hosted API gateway routing Claude Code through Amazon Bedrock with team API keys, budgets, rate limits, and OIDC SSO | Bedrock gateway|
 
 ## Framework Extensions
 


### PR DESCRIPTION
## What

Adds [Claude Code AWS Gateway](https://github.com/antkawam/claude-code-aws-gateway) to the **Proxy & API Tools** section.

## About the project

Self-hosted API gateway that routes Claude Code through Amazon Bedrock. Unlike other proxies in this section that bridge to different LLM providers, CCAG is purpose-built for teams using Amazon Bedrock and provides:

- **Team API key management** — virtual keys with per-key budgets and rate limits
- **OIDC SSO & SCIM provisioning** — integrate with your identity provider
- **Multi-endpoint routing** — distribute load across AWS accounts/regions with team-specific endpoint routing
- **Admin portal** — built-in dashboard for spend analytics and configuration
- **Web search** — intercepts `web_search` tool calls with multiple search providers
- **Drop-in setup** — just set `ANTHROPIC_BASE_URL`, no Bedrock-specific config in Claude Code

The gateway presents as the Anthropic Direct API, so Claude Code works without any special Bedrock configuration.