### PR TITLE
feat: add ClaudeCode Launchpad CLI to Development Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) | ![GitHub Repo stars](https://badgen.net/github/stars/noambrand/kivun-terminal) | 2-minute Windows & macOS installer for Claude Code — auto-installs Node.js, Git & Claude Code, live status bar with usage limits, desktop shortcut with folder picker | Windows & macOS installer|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
## What's being added

**[ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal)** — a 2-minute Windows & macOS installer for Claude Code.

Added to the **Development Tools & Utilities** section.

## Why it belongs here

Most users on Windows and macOS hit friction before they can run Claude Code for the first time (Node.js version conflicts, PATH issues, manual config). ClaudeCode Launchpad CLI removes that friction with a one-click installer, then adds:

- **Two-line live status bar** — model, context %, total tokens, session/weekly usage bars with reset timers
- **Desktop shortcut + folder picker** — launch Claude Code directly into any project folder
- **Right-click context menu** — "Open with ClaudeCode Launchpad CLI" on any folder (Windows)
- **Optional light-blue theme** — installer checkbox, keeps your terminal colors if unchecked
- **Claude flags support** — persistent flags in `config.txt` or one-time per launch
- **Multi-language** — Claude responds in your language (Hebrew, Arabic, and 20+ others)

Repo: https://github.com/noambrand/kivun-terminal