### PR TITLE
Add codachi to Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[codachi](https://github.com/vincent-k2026/codachi) | ![GitHub Repo stars](https://badgen.net/github/stars/vincent-k2026/codachi) | Tamagotchi-style statusline pet that reacts to context usage, git activity, and file types | Statusline pet|
 
 ## Proxy & API Tools
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
-|[codachi](https://github.com/vincent-k2026/codachi) | ![GitHub Repo stars](https://badgen.net/github/stars/vincent-k2026/codachi) | Tamagotchi-style statusline pet that reacts to context usage, git activity, and file types | Statusline pet|
+|[codachi](https://github.com/vincent-k2026/codachi) | ![GitHub Repo stars](https://badgen.net/github/stars/vincent-k2026/codachi) | Zero-dep statusline pet that predicts when you'll need `/compact` and reacts to git/file activity. `npx codachi init` to install | Statusline pet|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
Added codachi to the Monitoring & Analytics section — it's a statusline tool that shows an ASCII pet alongside context/git info. The pet grows with context usage and shows cache hit rate.