### PR TITLE
Add telegram-ai-bridge to Development Tools & Utilities

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -81,6 +81,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery) | ![GitHub Repo stars](https://badgen.net/github/stars/disler/claude-code-hooks-mastery) | 掌握 Claude Code hooks 以实现高级自动化 | Hooks 精通指南|
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Claude Code 通信工具 | 通信工具|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | 通过电子邮件、discord、telegram 远程控制 Claude Code | 远程控制工具|
+|[telegram-ai-bridge](https://github.com/AliceLJY/telegram-ai-bridge) | ![GitHub Repo stars](https://badgen.net/github/stars/AliceLJY/telegram-ai-bridge) | 通过 Telegram 运行 N 个并行 Claude Code 会话，支持 War Room 模式、A2A 多智能体协作 | Telegram 桥接|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Claude code 和 Codex 的零配置代码流 | 零配置工作流|
 
 ## 监控与分析

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery) | ![GitHub Repo stars](https://badgen.net/github/stars/disler/claude-code-hooks-mastery) | Master Claude Code hooks for advanced automation | Hooks mastery guide|
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
+|[telegram-ai-bridge](https://github.com/AliceLJY/telegram-ai-bridge) | ![GitHub Repo stars](https://badgen.net/github/stars/AliceLJY/telegram-ai-bridge) | Run N parallel Claude Code sessions from Telegram with War Room mode, per-bot personas, and A2A multi-agent collaboration | Telegram bridge|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
 
 ## Monitoring & Analytics


### PR DESCRIPTION
## What

Adding [telegram-ai-bridge](https://github.com/AliceLJY/telegram-ai-bridge) to the Development Tools & Utilities section (both English and Chinese READMEs).

telegram-ai-bridge lets you run N parallel Claude Code sessions from your phone via Telegram. Each bot runs a full CC instance (not an API wrapper) with shared memory across all instances. Features include War Room mode (@mention dispatch in group chats), per-bot personas via workspace CLAUDE.md, A2A multi-agent collaboration, tool approval from phone, and full session lifecycle management. Supports Claude Code, Codex, and Gemini backends.

Companion installer: [agent-nexus](https://github.com/AliceLJY/agent-nexus)