### PR TITLE
Add Onepilot to GUI & Web Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-chat](https://github.com/andrepimenta/claude-code-chat) | ![GitHub Repo stars](https://badgen.net/github/stars/andrepimenta/claude-code-chat) | Beautiful Claude Code Chat Interface for VS Code | VS Code chat interface|
 |[Claude-Code-Web-GUI](https://github.com/binggg/Claude-Code-Web-GUI) | ![GitHub Repo stars](https://badgen.net/github/stars/binggg/Claude-Code-Web-GUI) | Browse and view Claude Code session history in browser | Session history viewer|
 |[opcode](https://github.com/winfunc/opcode) | ![GitHub Repo stars](https://badgen.net/github/stars/winfunc/opcode) | Powerful GUI app and Toolkit for Claude Code with custom agents and interactive sessions | Advanced GUI toolkit|
+|[Onepilot](https://onepilotapp.com) | N/A | Native iOS SSH terminal for running Claude Code on remote servers with GitHub integration, localhost forwarding, live file editing, and AI agent deployment | Mobile terminal client|
 
 ## IDE & Editor Extensions
 


### PR DESCRIPTION
Adds [Onepilot](https://onepilotapp.com) to the GUI & Web Interfaces table.

Onepilot is a native iOS SSH terminal for running Claude Code on remote servers. It includes GitHub integration, localhost forwarding, live file editing, and AI agent deployment via OpenClaw.

- [App Store link](https://apps.apple.com/app/onepilot-ai-terminal/id6743826919)
- The only native mobile terminal client in this section — complements the existing web UIs and desktop tools