### PR TITLE
Add toprank to Additional Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ English | [简体中文](README-CN.md)
 |[CursorLens](https://github.com/HamedMP/CursorLens) | ![GitHub Repo stars](https://badgen.net/github/stars/HamedMP/CursorLens) | Open-source dashboard for Cursor.sh IDE | Cursor monitoring panel|
 |[win-claude-code](https://github.com/somersby10ml/win-claude-code) | ![GitHub Repo stars](https://badgen.net/github/stars/somersby10ml/win-claude-code) | Claude Code for Windows: No WSL. No Docker. Just code. | Windows native support|
 |[opencode](https://github.com/opencode-ai/opencode) | ![GitHub Repo stars](https://badgen.net/github/stars/opencode-ai/opencode) | A powerful AI coding agent built for the terminal | AI coding agent (archived)|
+|[toprank](https://github.com/nowork-studio/toprank) | ![GitHub Repo stars](https://badgen.net/github/stars/nowork-studio/toprank) | SEO & Google Ads plugin for Claude Code. 9 skills: audit, meta tags, JSON-LD schema, content writer, CMS connectors, ad campaigns, RSA copy | SEO/Ads plugin, MIT |
 
 ## Reverse Engineering & Analysis
 


### PR DESCRIPTION
Adds **toprank** — open-source Claude Code plugin with 9 SEO and Google Ads skills. Pulls Google Search Console, PageSpeed Insights, and Google Ads API data; ships fixes directly to source code or CMS (WordPress/Strapi/Contentful/Ghost). **107 ⭐, 14 🍴, MIT.**

- Source: https://github.com/nowork-studio/toprank