### PR TITLE
feat: add WhereMyTokens to Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) | ![GitHub Repo stars](https://badgen.net/github/stars/jeongwookie/WhereMyTokens) | Windows system tray app for real-time Claude Code token usage monitoring — sessions, costs, rate limits, context window | Windows tray monitor|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
## Description

Add [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) to the **Monitoring & Analytics** section.

## About the project

WhereMyTokens is a Windows system tray app for real-time Claude Code token usage monitoring. It reads local JSONL session files (no external data transmission) and displays per-session token counts, costs, rate limit progress bars, and context window usage.

- **Platform**: Windows 10/11
- **Tech**: Electron + React + TypeScript
- **License**: MIT

Fits alongside existing entries like `ccusage` and `ccseva` (macOS), filling the gap for Windows users.