### PR TITLE
Add Not Human Search to MCP Servers & Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ English | [简体中文](README-CN.md)
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
+|[nothumansearch](https://github.com/unitedideas/nothumansearch) | ![GitHub Repo stars](https://badgen.net/github/stars/unitedideas/nothumansearch) | Agent-first search engine — MCP server that helps Claude Code discover 8,000+ MCP servers and agent-readable sites, ranked across 7 agentic-readiness signals | Tool/MCP discovery|
 
 ## Guides & Documentation
 


### PR DESCRIPTION
## Summary

Adds [Not Human Search](https://nothumansearch.ai) (`unitedideas/nothumansearch`) to the **MCP Servers & Plugins** section.

NHS is an agent-first search engine exposed as an MCP server at `https://nothumansearch.ai/mcp`. It helps Claude Code (and other MCP-speaking agents) discover 8,000+ indexed MCP servers and agent-readable sites, ranked across 7 agentic-readiness signals (llms.txt, ai-plugin.json, OpenAPI, MCP manifest, JSON-RPC probe, robots.txt AI-bot allowlist, schema.org).

## Why it fits this list

- Claude Code users frequently need to find the right MCP server for a task. NHS is the tool-discovery layer for MCP.
- The MCP server exposes 8 tools including `search_sites`, `verify_mcp` (live JSON-RPC probe), `list_categories`, and `get_top_sites`.
- MIT licensed, no auth required, REST fallback at `/api/v1/search`.
- Listed in the official MCP registry as `ai.nothumansearch/search`.

## Entry

```
|[nothumansearch](https://github.com/unitedideas/nothumansearch) | ![GitHub Repo stars](https://badgen.net/github/stars/unitedideas/nothumansearch) | Agent-first search engine — MCP server that helps Claude Code discover 8,000+ MCP servers and agent-readable sites, ranked across 7 agentic-readiness signals | Tool/MCP discovery|
```

## Test plan

- [x] Entry follows existing table format (Name | Stars badge | Description | Notes)
- [x] Link targets a real, active MIT-licensed repo
- [x] Live MCP endpoint: `curl -X POST https://nothumansearch.ai/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`
- [x] Live REST endpoint: `curl https://nothumansearch.ai/api/v1/search?q=mcp`