### PR TITLE
Add ccthread to Development Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[ccthread](https://github.com/jakemarsh/ccthread) | ![GitHub Repo stars](https://badgen.net/github/stars/jakemarsh/ccthread) | Read, search, and have Claude summarize your Claude Code conversation logs from the CLI | Session log reader |
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
## Summary

Adds [ccthread](https://github.com/jakemarsh/ccthread) to Development Tools & Utilities.

ccthread is a CLI (and Claude Code plugin) that reads Claude Code conversation logs from `~/.claude/projects/` and turns each session's `.jsonl` into clean markdown. Useful for recalling decisions from past threads, summarizing work, finding forgotten values, or seeding `CLAUDE.md` from past sessions.

Tagline: *Read, search, and have Claude summarize your Claude Code conversation logs from the CLI.*

Same file layer as [ccundo](https://github.com/RonitSachdev/ccundo) and [ccusage](https://github.com/ryoppippi/ccusage) — different angle (conversation content rather than undo state or token usage).

## License

MIT.