### PR TITLE
Add EnigmAgent to MCP Servers section — AES-256-GCM encrypted credential vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ English | [简体中文](README-CN.md)
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
+|[EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) | ![GitHub Repo stars](https://badgen.net/github/stars/Agnuxo1/EnigmAgent) | AES-256-GCM + Argon2id encrypted local vault. Resolves `{{PLACEHOLDER}}` secrets at runtime — API keys never appear in prompts | Security credential vault|
 
 ## Guides & Documentation
 


### PR DESCRIPTION
## EnigmAgent — Encrypted Local Vault for AI Agent Credentials

**Repository:** https://github.com/Agnuxo1/EnigmAgent  
**npm:** `npm install -g enigmagent-mcp`

EnigmAgent is an AES-256-GCM + Argon2id encrypted local vault that prevents API keys from appearing in LLM context. Agents use `{{PLACEHOLDER}}` tokens; resolved at runtime.

- AES-256-GCM authenticated encryption + Argon2id key derivation
- Zero-knowledge local vault
- Works as stdio MCP server + REST API on port 3737