### PR TITLE
Add enigmagent-mcp to MCP Servers and Plugins

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -140,6 +140,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Claude Code 的简化 Gemini | Gemini 集成|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | 为 Claude Code 带来 Gemini AI 功能的轻量级 MCP 集成 | 轻量级 Gemini 集成|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | Claude Code 的 MCP Gemini 编程助手 | Gemini 编程助手|
+|[enigmagent-mcp](https://github.com/Agnuxo1/enigmagent-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/Agnuxo1/enigmagent-mcp) | 加密本地保险库 MCP（AES-256-GCM + Argon2id） — 在运行时解析 `{{PLACEHOLDER}}` 占位符，使 API 密钥永不进入 LLM 提示、日志或上下文 | 凭据保险库 MCP|
 
 ## 指南与文档
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ English | [简体中文](README-CN.md)
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
+|[enigmagent-mcp](https://github.com/Agnuxo1/enigmagent-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/Agnuxo1/enigmagent-mcp) | Encrypted local vault MCP (AES-256-GCM + Argon2id) — resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never enter LLM prompts, logs, or context | Credential vault MCP|
 
 ## Guides & Documentation
 


### PR DESCRIPTION
Suggesting **EnigmAgent**, an open-source MCP server that fits this list cleanly.

It is an encrypted local vault that resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never appear in LLM prompts, logs, or context windows. AES-256-GCM + Argon2id, local-only, MIT licensed.

- Repo: https://github.com/Agnuxo1/enigmagent-mcp
- npm: `npx enigmagent-mcp` — https://www.npmjs.com/package/enigmagent-mcp
- Glama security: A — https://glama.ai/mcp/servers/Agnuxo1/enigmagent-mcp

Happy to adjust the description, section, or format if you prefer.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>