### PR TITLE
Add Agent Sessions

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -52,6 +52,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[claude-code-chat](https://github.com/andrepimenta/claude-code-chat) | ![GitHub Repo stars](https://badgen.net/github/stars/andrepimenta/claude-code-chat) | 美观的 VS Code Claude Code 聊天界面 | VS Code 聊天界面|
 |[Claude-Code-Web-GUI](https://github.com/binggg/Claude-Code-Web-GUI) | ![GitHub Repo stars](https://badgen.net/github/stars/binggg/Claude-Code-Web-GUI) | 在浏览器中浏览和查看 Claude Code 会话历史 | 会话历史查看器|
 |[opcode](https://github.com/winfunc/opcode) | ![GitHub Repo stars](https://badgen.net/github/stars/winfunc/opcode) | 强大的 Claude Code GUI 应用和工具包，支持自定义代理和交互式会话 | 高级 GUI 工具包|
+|[Agent Sessions](https://github.com/jazzyalex/agent-sessions) | ![GitHub Repo stars](https://badgen.net/github/stars/jazzyalex/agent-sessions) | 原生 macOS 应用，用于浏览、搜索和恢复本地 Claude Code 会话，并支持 Codex、Gemini CLI、OpenCode 等编程代理 | 会话历史查看器|
 
 ## IDE与编辑器扩展
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-chat](https://github.com/andrepimenta/claude-code-chat) | ![GitHub Repo stars](https://badgen.net/github/stars/andrepimenta/claude-code-chat) | Beautiful Claude Code Chat Interface for VS Code | VS Code chat interface|
 |[Claude-Code-Web-GUI](https://github.com/binggg/Claude-Code-Web-GUI) | ![GitHub Repo stars](https://badgen.net/github/stars/binggg/Claude-Code-Web-GUI) | Browse and view Claude Code session history in browser | Session history viewer|
 |[opcode](https://github.com/winfunc/opcode) | ![GitHub Repo stars](https://badgen.net/github/stars/winfunc/opcode) | Powerful GUI app and Toolkit for Claude Code with custom agents and interactive sessions | Advanced GUI toolkit|
+|[Agent Sessions](https://github.com/jazzyalex/agent-sessions) | ![GitHub Repo stars](https://badgen.net/github/stars/jazzyalex/agent-sessions) | Native macOS app to browse, search, and resume local Claude Code sessions alongside Codex, Gemini CLI, OpenCode, and other coding agents | Session history viewer|
 
 ## IDE & Editor Extensions
 


### PR DESCRIPTION
Adds Agent Sessions to the GUI & Web Interfaces section in both the English and Chinese READMEs.

Agent Sessions is a native macOS app for browsing, searching, and resuming local Claude Code sessions alongside Codex, Gemini CLI, OpenCode, and other coding agents.