### PR TITLE
Add cc-cost to Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[cc-cost](https://github.com/lob-labs/cc-cost) | ![GitHub Repo stars](https://badgen.net/github/stars/lob-labs/cc-cost) | Single-file Python CLI: parses Claude Code transcript JSONL, reports cost / cache hit rate / tool-call distribution / top expensive turns / actionable optimization recommendations | Cost analysis CLI|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
Adds [cc-cost](https://github.com/lob-labs/cc-cost) — a single-file Python CLI that parses Claude Code transcript JSONL and reports cost, cache hit rate, tool-call distribution, top expensive turns, and actionable optimization recommendations (`--diagnose`).

Fits the **Monitoring & Analytics** section alongside `Claude-Code-Usage-Monitor`, `sniffly`, `claude-code-costs`, `claude-code-otel`.

- Repo: https://github.com/lob-labs/cc-cost
- License: MIT
- Single file, no third-party deps, Python 3.9+
- `pipx install git+https://github.com/lob-labs/cc-cost.git`

Thanks for maintaining this list!