### PR TITLE
Add agenttrace

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -93,6 +93,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Claude Code 使用的成本跟踪 | 成本跟踪工具|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | 将 Claude Code 聊天会话导出为 markdown 和 XML | 会话导出工具|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | 监控 Claude Code 使用、性能和成本的综合可观察性解决方案 | 可观察性解决方案|
+|[agenttrace](https://github.com/luoyuctl/agenttrace) | ![GitHub Repo stars](https://badgen.net/github/stars/luoyuctl/agenttrace) | 本地优先的 AI 编程代理会话日志 TUI，跟踪成本、Token、延迟、工具失败、差异、报告和 CI 门禁 | TUI 可观察性|
 
 ## 代理与API工具
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[agenttrace](https://github.com/luoyuctl/agenttrace) | ![GitHub Repo stars](https://badgen.net/github/stars/luoyuctl/agenttrace) | Local-first TUI for AI coding-agent session logs, tracking cost, tokens, latency, tool failures, diffs, reports, and CI gates | TUI observability|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
## Summary
- Add agenttrace to the Monitoring & Analytics section.
- Update both English and Simplified Chinese README entries.

## Why
- agenttrace is a local TUI observability dashboard for AI coding agent sessions, including Claude Code-style logs, cost, token usage, latency, tool failures, anomalies, health, and diffs.

## Checks
- README-only change; inspected the table diff locally.