### PR TITLE
Add zero-api-key-web-search: Free web search MCP server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ English | [简体中文](README-CN.md)
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
+|[zero-api-key-web-search](https://github.com/wd041216-bit/zero-api-key-web-search) | ![GitHub Repo stars](https://badgen.net/github/stars/wd041216-bit/zero-api-key-web-search) | Free web search toolkit for AI agents with no API keys, MCP server ready | MCP server|
 
 ## Guides & Documentation
 


### PR DESCRIPTION
## Summary

Added **zero-api-key-web-search** to the MCP Servers list.

A Python toolkit that equips AI agents with live web search capabilities without requiring API keys or account creation. Uses DuckDuckGo as default provider, with optional SearXNG self-hosting and Bright Data integration for production use.

- MCP server with 8 tools
- Citation-ready context extraction
- Free by default