### PR TITLE
Add TokenWise to Monitoring & Analytics

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -93,6 +93,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Claude Code 使用的成本跟踪 | 成本跟踪工具|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | 将 Claude Code 聊天会话导出为 markdown 和 XML | 会话导出工具|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | 监控 Claude Code 使用、性能和成本的综合可观察性解决方案 | 可观察性解决方案|
+|[tokenwise](https://github.com/CodeShuX/tokenwise) | ![GitHub Repo stars](https://badgen.net/github/stars/CodeShuX/tokenwise) | 测量驱动的模型路由器 — 自动将任务路由到 Haiku/Sonnet，仅在合成时使用 Opus，记录每个路由任务的实际节省成本 | 成本降低 + A/B 测试|
 
 ## 代理与API工具
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[tokenwise](https://github.com/CodeShuX/tokenwise) | ![GitHub Repo stars](https://badgen.net/github/stars/CodeShuX/tokenwise) | Measurement-driven model router — auto-routes work to Haiku/Sonnet, reserves Opus for synthesis, logs every routed task with real $ saved | Cost reduction + A/B testing|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
## Summary

Adds [TokenWise](https://github.com/CodeShuX/tokenwise) under **Monitoring & Analytics** in both \`README.md\` and \`README-CN.md\`.

## What it does

A Claude Code skill that auto-routes subtasks across Haiku, Sonnet, and Opus based on task class, then logs every routed task to a local NDJSON with real token + cost numbers. Includes an A/B test subcommand that runs the same task across multiple tiers and scores quality.

- **Routes**: Haiku for grunt work, Sonnet for scoped reasoning, Opus only for synthesis
- **Measures**: every routed task logged with real \$ numbers, zero telemetry, local-only
- **Proves**: \`/tokenwise:ab\` validates the cheaper tier before you trust it
- **Privacy**: no analytics endpoint, file contents never logged

## Why this section

Fits naturally alongside \`Claude-Code-Usage-Monitor\`, \`claude-code-costs\`, \`ccusage\`, and \`claude-code-otel\` — all cost/usage tools. TokenWise is the only entry that **routes** while measuring (others only observe).

## Files updated

- \`README.md\` — added row under \`## Monitoring & Analytics\`
- \`README-CN.md\` — added row under \`## 监控与分析\`

License: MIT