### PR TITLE
Add oh-story-claudecode - 网文写作工具箱

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection) | ![GitHub Repo stars](https://badgen.net/github/stars/davepoon/claude-code-subagents-collection) | Claude Code Subagents & Commands Collection + CLI Tool | Subagents CLI tool|
 |[awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/vijaythecoder/awesome-claude-agents) | Orchestrated sub agent dev team powered by claude code | Sub agent dev team|
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
+|[oh-story-claudecode](https://github.com/worldwonderer/oh-story-claudecode) | ![GitHub Repo stars](https://badgen.net/github/stars/worldwonderer/oh-story-claudecode) | 网文写作工具箱 — 13 skills + 6 agents 覆盖长篇/短篇网文扫榜、拆文、写作、去AI味全流程 | Chinese web novel writing toolkit|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
 


### PR DESCRIPTION
## Summary

添加 [oh-story-claudecode](https://github.com/worldwonderer/oh-story-claudecode) — 中文网络小说写作 skill 包。

**功能：**
- 13 个 Skill 覆盖长篇/短篇网文全流程：扫榜（起点/番茄/晋江/知乎）、拆文、写作、去AI味、封面生成、逆向导入
- 6 个专业 Agent：故事架构师、角色设计师、叙事写手、一致性检查、资料研究、故事查询
- 自动化 Hooks：会话恢复、设定缺口检测、提交验证
- 1k+ Stars，持续维护中

**安装：**
```bash
npx skills add worldwonderer/oh-story-claudecode
```

放在 Framework Extensions 分类，跟 superpowers 等其他 skill/agent 集合放在一起。如有更合适的位置请告知调整。