### PR TITLE
Add Septim Agents Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ English | [简体中文](README-CN.md)
 
 ## Framework Extensions
 
+- [Septim Agents Pack](https://septimlabs.com/agents) - 10 named Claude Code sub-agents for ~/.claude/agents/ (full exec layer for solo founders). MIT sample at github.com/septimlabs-code/septim-agents-pack-sample.
 |Name|Stars|Description|Notes|
 |-------|-------|-------|------|
 |[n8n-mcp](https://github.com/czlonkowski/n8n-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/czlonkowski/n8n-mcp) | MCP for Claude Desktop/Code to build n8n workflows | n8n workflow integration|


### PR DESCRIPTION
Adds the [Septim Agents Pack](https://septimlabs.com/agents) — 10 named Claude Code sub-agents covering the full exec layer for solo founders (chief of staff, CTO, brand, CMO, CFO, design, legal, customer, research, intern coordinator).

The pack ships under the Claude Code sub-agent framework: each agent is a markdown file dropped into `~/.claude/agents/`, invoked via `/agents <name>`.

One agent (Pip the intern) is open-sourced under MIT at https://github.com/septimlabs-code/septim-agents-pack-sample so anyone can see the exact named-agent + scope + refusal-conditions format before buying the full pack.

Thanks for maintaining this list.
