### PR TITLE
Add Agent FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-log](https://github.com/daaain/claude-code-log) | ![GitHub Repo stars](https://badgen.net/github/stars/daaain/claude-code-log) | Convert Claude Code transcript JSONL files into readable HTML format | Log conversion tool|
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
+|[Agent FM](https://github.com/agentfm-ai/agent-fm) | ![GitHub Repo stars](https://badgen.net/github/stars/agentfm-ai/agent-fm) | Local macOS companion for Claude Code and Codex sessions that narrates progress, blockers, decisions, and attention requests in real time | Ambient awareness|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
 
 ## Proxy & API Tools


### PR DESCRIPTION
Adds Agent FM to Monitoring & Analytics.

Agent FM is a local macOS companion for Claude Code and Codex sessions. It narrates progress, blockers, decisions, and attention requests so developers can monitor active local sessions without reading every terminal.

I added it here because it fits as an ambient monitoring/awareness tool for Claude Code workflows.
