### PR TITLE
Add AI Memory Reader (原生 macOS/iOS 内存文件浏览器)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-chat](https://github.com/andrepimenta/claude-code-chat) | ![GitHub Repo stars](https://badgen.net/github/stars/andrepimenta/claude-code-chat) | Beautiful Claude Code Chat Interface for VS Code | VS Code chat interface|
 |[Claude-Code-Web-GUI](https://github.com/binggg/Claude-Code-Web-GUI) | ![GitHub Repo stars](https://badgen.net/github/stars/binggg/Claude-Code-Web-GUI) | Browse and view Claude Code session history in browser | Session history viewer|
 |[opcode](https://github.com/winfunc/opcode) | ![GitHub Repo stars](https://badgen.net/github/stars/winfunc/opcode) | Powerful GUI app and Toolkit for Claude Code with custom agents and interactive sessions | Advanced GUI toolkit|
+|[AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) | ![GitHub Repo stars](https://badgen.net/github/stars/nvwalj/ai-memory-reader) | Native macOS & iOS app for browsing AI agent memory files (CLAUDE.md etc.). Auto-detects Claude Code, OpenClaw, Codex, Cursor, Gemini directories. SwiftUI + MarkdownUI, sidebar tree, edit mode with auto-save, URL scheme + CLI for agent integration. | Native Mac/iOS memory viewer |
 
 ## IDE & Editor Extensions
 


### PR DESCRIPTION
Adds [AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) to the **GUI & Web Interfaces** section.

加入 [AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) 到 GUI & Web Interfaces 列表。

**这是什么？**

唯一一个原生 macOS / iOS 应用,用来浏览和编辑 AI 代理的内存文件 (CLAUDE.md, AGENTS.md 等)。其他工具大多是 CLI 或网页 dashboard,这个填补了原生应用的空白。

**自动识别**以下 AI 工具的内存目录:
- Claude Code (`~/.claude` 和项目级 CLAUDE.md)
- OpenClaw, Codex, Cursor, Gemini, Continue, Aider, GitHub Copilot

**特性:**
- GitHub 风格 Markdown 渲染 (基于 MarkdownUI)
- 侧栏文件树 + 右侧目录大纲
- ⌘F 页内搜索 (字符级高亮), ⌘E 编辑模式 (自动保存)
- URL Scheme + CLI (`aimr`) — 给 AI 代理调用
- Universal binary, 同时支持 Apple Silicon 和 Intel Mac

**仓库**: https://github.com/nvwalj/ai-memory-reader
**Release**: v0.4.0 ships 一个可直接下载的 .zip
**License**: GPL-3.0