### PR TITLE
Add capcut-cli (CapCut/JianYing draft editor CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ English | [简体中文](README-CN.md)
 |[CursorLens](https://github.com/HamedMP/CursorLens) | ![GitHub Repo stars](https://badgen.net/github/stars/HamedMP/CursorLens) | Open-source dashboard for Cursor.sh IDE | Cursor monitoring panel|
 |[win-claude-code](https://github.com/somersby10ml/win-claude-code) | ![GitHub Repo stars](https://badgen.net/github/stars/somersby10ml/win-claude-code) | Claude Code for Windows: No WSL. No Docker. Just code. | Windows native support|
 |[opencode](https://github.com/opencode-ai/opencode) | ![GitHub Repo stars](https://badgen.net/github/stars/opencode-ai/opencode) | A powerful AI coding agent built for the terminal | AI coding agent (archived)|
+|[capcut-cli](https://github.com/renezander030/capcut-cli) | ![GitHub Repo stars](https://badgen.net/github/stars/renezander030/capcut-cli) | Zero-dep CLI to edit CapCut and JianYing video drafts (draft_content.json). Subtitles, decorators, templates, long-form-to-shorts. Both namespaces in one binary. | Video automation CLI|
 
 ## Reverse Engineering & Analysis
 


### PR DESCRIPTION
Hi,

Adding **[capcut-cli](https://github.com/renezander030/capcut-cli)** to Additional Tools & Utilities.

**What it is:** a zero-dependency Node CLI for editing CapCut and JianYing video drafts (`draft_content.json`) directly from the shell. Pairs naturally with Claude Code (and any LLM that returns JSON) for short-video automation pipelines.

**Why bilingual users will care:**
- Full 中文 README + JianYing 剪映 namespace support (most CN ecosystem tools are Python-only — this is Node, zero deps)
- Real CN audience: ~11% of repo traffic lands on the zh-CN README; Chinese stargazers + forks from xinghua2019, wangci123, wxxxcxx, wk23415, etc.
- Ships a Claude Code plugin (`/plugin marketplace add https://github.com/renezander030/capcut-cli`)

**Why it's distinct from existing entries:** all the other tools listed are agent-runner / Claude-Code-itself helpers — capcut-cli is a domain CLI that LLMs *drive*, not a Claude alternative.

**Stats:** 22 ⭐, MIT, npm package, 60+ tests, 3,700-line schema docs, v0.4 ships caption factory + version migrate/lint + multi-language draft clone.

Rene