### PR TITLE
Add: ndesv21/socialclaw — social media scheduling and publishing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [简体中文](README-CN.md)
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
+|[socialclaw](https://github.com/ndesv21/socialclaw) | ![GitHub Repo stars](https://badgen.net/github/stars/ndesv21/socialclaw) | Schedule and publish social media posts across 13 platforms via SocialClaw API | Social media publishing skill|
 
 ## MCP Servers & Plugins
 


### PR DESCRIPTION
Adds [ndesv21/socialclaw](https://github.com/ndesv21/socialclaw) to the Core Extensions & Integrations section.

SocialClaw is a social media publishing skill for Claude Code that connects to 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) through a single workspace API key.

- Install: `npx skills add ndesv21/socialclaw`
- Dashboard: https://getsocialclaw.com
- License: MIT