### PR TITLE
docs: add claude-code-dna to Framework Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [简体中文](README-CN.md)
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
+|[claude-code-dna](https://github.com/huangji6693-max/claude-code-dna) | ![GitHub Repo stars](https://badgen.net/github/stars/huangji6693-max/claude-code-dna) | Behavioral OS for Claude Code — Karpathy 4 laws + 15 operating instincts + memory architecture + curated catalog (194 skills + 99 agents) | Behavioral DNA + memory architecture|
 
 ## MCP Servers & Plugins
 


### PR DESCRIPTION
## What

Adds [claude-code-dna](https://github.com/huangji6693-max/claude-code-dna) to the **Framework Extensions** section.

## Why

Distinct positioning from existing entries:

- Not a skill bundle — ships **behavioral DNA** (Karpathy's 4 laws + 15 operating instincts + verification gate + TDD reflex).
- Includes a **memory architecture** (mem0 v3 ADD-only + langmem 3-types × 2-timings + GraphRAG community summaries) so the agent stops bloating context with stale notes.
- Provides a **curated catalog** of 194 skills + 99 agents — categorized, keyword-indexed, agentskills.io-spec-audited — instead of redistributing source code.
- Ships 3 portable scripts (`memory-health.sh`, BM25-style `memory-search.sh`, `skill-spec-audit.sh`) — bash + awk + python3, no extra deps.

Synthesized from 11 deeply-read libraries (anthropics/skills, obra/superpowers, mem0, langmem, GraphRAG, Karpathy, Warp, ruvnet/claude-flow, etc.). MIT licensed.

## Where

Section: **Framework Extensions** — added one row after the `claude-agents` entry, before the **MCP Servers & Plugins** heading.

## Checklist

- [x] Single entry, in the correct section
- [x] Brief, neutral, factual description
- [x] Link goes to canonical repo