### PR TITLE
Add claude-code-dna to Framework Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [简体中文](README-CN.md)
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
+|[claude-code-dna](https://github.com/huangji6693-max/claude-code-dna) | ![GitHub Repo stars](https://badgen.net/github/stars/huangji6693-max/claude-code-dna) | Behavioral OS for Claude Code agents — Karpathy 4 laws + 15 operating instincts + memory architecture (mem0/langmem/GraphRAG) + curated 194-skill/99-agent catalog with agentskills.io spec audit | Behavioral rules + memory architecture|
 
 ## MCP Servers & Plugins
 


### PR DESCRIPTION
## What

Added one row to the **Framework Extensions** table:

| Name | Description |
|------|-------------|
| [claude-code-dna](https://github.com/huangji6693-max/claude-code-dna) | Behavioral OS for Claude Code agents — Karpathy 4 laws + 15 operating instincts + memory architecture + curated 194-skill/99-agent catalog with agentskills.io spec audit |

## Why this category

It is a behavioral rules + memory architecture package, complementary to:

- **superpowers** / **agents** (which provide skill/agent source code) → claude-code-dna teaches the agent *how* to use them without breaking Karpathy's 4 laws (Think / Simplicity / Surgical / Goal-driven)
- **awesome-claude-code-subagents** / **claude-code-sub-agents** (which provide subagent definitions) → claude-code-dna indexes 99 of them with category + keyword + compliance score

## What it provides

- 8 rule files codifying behavioral reflexes (verification gate before "done", TDD reflex, root cause before fix, no refactor-while-fixing)
- 3-tier memory architecture inspired by mem0 v3, langmem, and Microsoft GraphRAG — persistent across sessions without bloating each conversation's context
- 3 portable scripts: memory-health.sh / memory-search.sh / skill-spec-audit.sh (168 PASS / 23 WARN / 3 FAIL on 194 community skills)
- Curated catalog of 194 skills + 99 agents with category, trigger keyword, and spec-compliance score

## Compatibility

- Zero secrets, zero project data, zero telemetry
- Model-agnostic — works in Cursor, Codex, Gemini CLI
- 30-second install: `git clone && ./install.sh`
- MIT license

Happy to adjust the row format or move to a different section if you prefer. Thanks for maintaining this list! 🙏