### PR TITLE
Add usage to Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[usage](https://github.com/aqua5230/usage) | ![GitHub Repo stars](https://badgen.net/github/stars/aqua5230/usage) | macOS menu bar app that pins Claude Code and Codex quota, tokens, and cost. Local-only — reads a statusLine hook (Claude Code) and JSONL session logs (Codex); no API calls. HTML reports and TUI mode included. | macOS menu bar monitor|
 
 ## Proxy & API Tools
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
-|[usage](https://github.com/aqua5230/usage) | ![GitHub Repo stars](https://badgen.net/github/stars/aqua5230/usage) | macOS menu bar app that pins Claude Code and Codex quota, tokens, and cost. Local-only — reads a statusLine hook (Claude Code) and JSONL session logs (Codex); no API calls. HTML reports and TUI mode included. | macOS menu bar monitor|
+|[usage](https://github.com/aqua5230/usage) | ![GitHub Repo stars](https://badgen.net/github/stars/aqua5230/usage) | macOS menu bar and Windows tray app that pins Claude Code, Codex, and Antigravity quota, tokens, and cost. Claude Code and Codex are read from a statusLine hook and JSONL session logs with no LLM API calls. HTML reports and TUI mode included. | macOS menu bar monitor|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
Adds [usage](https://github.com/aqua5230/usage) — a macOS menu bar app that pins Claude Code and Codex quota, tokens, and cost to your screen.

- 147 ⭐ as of submission
- Local-only: reads a statusLine hook (Claude Code) and JSONL session logs (Codex); no API calls
- Includes HTML reports, a TUI mode, and 9 themes
- AGPL-3.0, Python + PyObjC

Added to the Monitoring & Analytics table following the existing format.