### PR TITLE
Add CoderPlan — 统一 LLM API 网关（Proxy & API Tools）

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ English | [简体中文](README-CN.md)
 |[anyclaude](https://github.com/coder/anyclaude) | ![GitHub Repo stars](https://badgen.net/github/stars/coder/anyclaude) | Claude Code with any LLM | Multi-model support|
 |[claude-code-open](https://github.com/Davincible/claude-code-open) | ![GitHub Repo stars](https://badgen.net/github/stars/Davincible/claude-code-open) | Claude Code with any LLM provider | Open LLM support|
 
+|[CoderPlan](https://coderplan.ai) | [Website](https://coderplan.ai) | Unified LLM API gateway for Claude Code — OpenAI compatible, pay-as-you-go at ~7% of official pricing, direct access from China | API gateway & relay|
+
 ## Framework Extensions
 
 |Name|Stars|Description|Notes|


### PR DESCRIPTION
## 添加 CoderPlan 到 Proxy & API Tools 部分

### 工具信息

- **名称**: CoderPlan
- **官网**: https://coderplan.ai
- **分类**: Proxy & API Tools

### 简介

CoderPlan 是面向开发者的统一 LLM API 网关，提供 OpenAI 兼容的 API 端点。支持 Claude、GPT、Gemini、DeepSeek 等主流模型，按量付费约官方 0.7 折。国内直连无需翻墙，支付宝/微信支付。

### 为什么适合收录

1. **Claude Code 用户刚需**: 一行配置即可将 Claude Code 指向 CoderPlan 端点，无需官方 API Key
2. **与现有条目互补**: y-router 需要 OpenRouter 账号，claude-code-proxy 需自建。CoderPlan 是托管方案，开箱即用
3. **国内开发者友好**: 直连、支付宝/微信支付 — 填补现有条目的空白
4. **多模型支持**: 不仅限于 Claude，还支持 GPT、Gemini、DeepSeek 等

### 条目格式

严格按照 README 现有表格格式添加，与其他 Proxy & API Tools 条目保持一致。

---

感谢云中江树维护这个优秀的资源库！