### PR TITLE
feat: add CoderPlan to Proxy & API Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-openai-wrapper](https://github.com/RichardAtCT/claude-code-openai-wrapper) | ![GitHub Repo stars](https://badgen.net/github/stars/RichardAtCT/claude-code-openai-wrapper) | OpenAI API-compatible wrapper for Claude Code | OpenAI compatible wrapper|
 |[anyclaude](https://github.com/coder/anyclaude) | ![GitHub Repo stars](https://badgen.net/github/stars/coder/anyclaude) | Claude Code with any LLM | Multi-model support|
 |[claude-code-open](https://github.com/Davincible/claude-code-open) | ![GitHub Repo stars](https://badgen.net/github/stars/Davincible/claude-code-open) | Claude Code with any LLM provider | Open LLM support|
+|[CoderPlan](https://coderplan.ai) | ![website](https://img.shields.io/badge/website-coderplan.ai-blue) | OpenAI-compatible LLM API gateway for Claude Code, Cursor and AI coding tools | API relay / pay-per-use|
 
 ## Framework Extensions
 


### PR DESCRIPTION
## Addition

Added **CoderPlan** to the Proxy & API Tools section.

### About CoderPlan
- **Website**: https://coderplan.ai
- **Description**: OpenAI-compatible LLM API gateway for developers. Connect Claude Code, Cursor, Windsurf and other AI coding tools to all major models (Claude, GPT-4, Gemini, etc.) through a single endpoint.
- **Pricing**: Freemium (free tier + pay-per-use)

### Why it fits
CoderPlan is directly relevant to the Claude Code ecosystem — it provides an OpenAI-compatible API endpoint that Claude Code users can configure as their model provider, similar to the other proxy tools already listed in this section (claude-code-proxy, y-router, etc.).

### Checklist
- [x] Entry follows existing table format (Name, Stars badge, Description, Notes)
- [x] Added at the end of the Proxy & API Tools section
- [x] Description is concise and accurate