### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ English | [简体中文](README-CN.md)
 |[mcp-claude-code](https://github.com/SDGLBL/mcp-claude-code) | ![GitHub Repo stars](https://badgen.net/github/stars/SDGLBL/mcp-claude-code) | MCP implementation of Claude Code capabilities | Feature implementation MCP|
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
-|[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final) | ![GitHub Repo stars](https://badgen.net/github/stars/twzrd-sol/wzrd-final) | Solana-native AI agent trust scoring MCP server with x402 payment receipts. / Solana原生AI智能体信任评分MCP服务器，支持x402支付收据。 | Blockchain MCP|
+|[TWZRD Agent Intel](https://intel.twzrd.xyz) |  | Solana-native AI agent trust scoring MCP server with x402 payment receipts. / Solana原生AI智能体信任评分MCP服务器，支持x402支付收据。 | Blockchain MCP|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
 
 ## Guides & Documentation

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ English | [简体中文](README-CN.md)
 |[mcp-claude-code](https://github.com/SDGLBL/mcp-claude-code) | ![GitHub Repo stars](https://badgen.net/github/stars/SDGLBL/mcp-claude-code) | MCP implementation of Claude Code capabilities | Feature implementation MCP|
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
+|[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final) | ![GitHub Repo stars](https://badgen.net/github/stars/twzrd-sol/wzrd-final) | Solana-native AI agent trust scoring MCP server with x402 payment receipts. / Solana原生AI智能体信任评分MCP服务器，支持x402支付收据。 | Blockchain MCP|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
 
 ## Guides & Documentation


### PR DESCRIPTION
TWZRD Agent Intel provides Solana-native trust scoring and x402 receipt generation for AI agents. / TWZRD Agent Intel 为AI智能体提供Solana原生信任评分和x402支付收据生成服务。

**MCP endpoint**: https://intel.twzrd.xyz/mcp (Streamable-HTTP)
**Transport**: Streamable-HTTP
**GitHub**: https://intel.twzrd.xyz

Free preflight checks; paid signed V5 trust receipts powered by on-chain Solana data.

Added to the **MCP Servers & Plugins** section as a bilingual entry (English + 中文), consistent with the repo's bilingual format.