### PR TITLE
feat: add ProposalCraft to MCP Servers — freelance proposal drafting MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ English | [简体中文](README-CN.md)
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
+|[proposalcraft](https://github.com/jabbawocky/proposalcraft) | ![GitHub Repo stars](https://badgen.net/github/stars/jabbawocky/proposalcraft) | MCP server for freelancers: paste a client brief, get a proposal drafted in your voice from past winning work. Free tier (5 drafts/month), no API key required | Freelance proposal MCP|
 
 ## Guides & Documentation
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ English | [简体中文](README-CN.md)
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
 |[proposalcraft](https://github.com/jabbawocky/proposalcraft) | ![GitHub Repo stars](https://badgen.net/github/stars/jabbawocky/proposalcraft) | MCP server for freelancers: paste a client brief, get a proposal drafted in your voice from past winning work. Free tier (5 drafts/month), no API key required | Freelance proposal MCP|
+|[standupcraft](https://github.com/jabbawocky/standupcraft) | ![GitHub Repo stars](https://badgen.net/github/stars/jabbawocky/standupcraft) | MCP server that reads git commits and GitHub activity to generate daily standups, weekly client reports, and sprint retros inside Claude Desktop. No API key required | Developer standup MCP|
 
 ## Guides & Documentation
 


### PR DESCRIPTION
Adds [ProposalCraft](https://github.com/jabbawocky/proposalcraft) to the MCP Servers & Plugins section.

ProposalCraft is an MCP server that helps freelancers and consultants draft client proposals in their own voice using past winning proposals as reference. Works with Claude Code and Claude Desktop.

- **8 MCP tools**: `analyze_brief`, `draft_proposal`, `save_proposal`, `usage_status`, and more
- **Free tier**: 5 `draft_proposal` calls/month, no API key needed
- **Install**: `claude mcp add proposalcraft npx -- -y github:jabbawocky/proposalcraft`
- TypeScript, MIT license, privacy-first (proposals stored locally)