### PR TITLE
Add ccline - zsh natural language shell integration for Claude CLI users

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[ccline](https://github.com/jianshuo/ccline) | ![GitHub Repo stars](https://badgen.net/github/stars/jianshuo/ccline) | Type a natural-language thought at your zsh prompt, get a Claude AI answer, run suggested commands with one keypress in your live shell | zsh shell integration|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
## ccline

**ccline** is a zsh shell integration that brings Claude Code's intelligence to your everyday terminal workflow.

**How it works:** Type a natural-language thought directly at your zsh prompt (no command prefix needed). ccline hijacks `command_not_found_handler`:
- One word → normal `command not found` typo behavior
- Two or more words → sent to Claude (or Codex as fallback), answer rendered as Markdown

Any suggested shell commands can be run with one keypress in your **live shell** — `cd`, `export`, history all persist.

```sh
$ how do I find files bigger than 100MB here

    find . -maxdepth 1 -type f -size +100M

Commands found — ↑/↓ to choose, Enter to run:
 ❯ find . -maxdepth 1 -type f -size +100M
```

**Install:** `curl -fsSL https://raw.githubusercontent.com/jianshuo/ccline/v0.2.2/install.sh | bash`

GitHub: https://github.com/jianshuo/ccline