### PR TITLE
feat: add Headroom to Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[Headroom](https://github.com/patwalls/headroom) | ![GitHub Repo stars](https://badgen.net/github/stars/patwalls/headroom) | Native macOS menu bar app showing Claude Code 5h/7d usage % live — zero network calls, reads data Claude Code writes locally | macOS menu bar app|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
## What

Adds [Headroom](https://github.com/patwalls/headroom) to the **Monitoring & Analytics** section.

## Why it fits

Headroom is the only native macOS menu bar app in the monitoring category — all existing entries are Python CLIs or web dashboards. It complements those tools with a different form factor: always-visible, always-current usage % in the menu bar, without opening a terminal or browser.

**Key facts:**
- Shows Claude Code 5-hour session and 7-day weekly utilization % live, color-coded (calm → amber → red as a limit approaches)
- **Zero network calls** — reads data Claude Code itself writes locally via a statusLine hook (no API key, no token, no Keychain, no telemetry)
- Native Swift/AppKit macOS app, signed & notarized, free
- Install: `brew install --cask patwalls/tap/headroom` or download from https://headroom.walls.sh
- MIT license, open source

| Field | Value |
|---|---|
| Stars | ~130 |
| License | MIT |
| Platform | macOS 13+ |
| Install | brew cask or .zip download |