### PR TITLE
Add video-overlay-kit MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ English | [简体中文](README-CN.md)
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
+|[video-overlay-kit](https://github.com/alichherawalla/video-overlay-kit) | ![GitHub Repo stars](https://badgen.net/github/stars/alichherawalla/video-overlay-kit) | Render 4-6s animated b-roll overlay videos for short-form social (LinkedIn, IG Reels, YouTube Shorts, TikTok). MCP server hands Claude Code tools to write the scene spec and render the mp4 from your script. Built on Remotion + Tabler + Lottie. | Video overlay rendering MCP|
 
 ## Guides & Documentation
 


### PR DESCRIPTION
Adds [video-overlay-kit](https://github.com/alichherawalla/video-overlay-kit) to the MCP Servers & Plugins table.

It's an open-source MCP server that exposes tools for rendering 4-6s animated b-roll overlay videos from a script. Targeted at short-form social content (LinkedIn, IG Reels, YouTube Shorts, TikTok) and landscape YouTube. Built on Remotion, Tabler, and LottieFiles. MIT, local rendering.