### PR TITLE
Add claude-screenwriting to framework extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [简体中文](README-CN.md)
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
+|[claude-screenwriting](https://github.com/e06084/claude-screenwriting) | ![GitHub Repo stars](https://badgen.net/github/stars/e06084/claude-screenwriting) | Structured screenwriting skills for Claude Code + Obsidian | Vogler/McKee/Save the Cat workflows|
 
 ## MCP Servers & Plugins
 


### PR DESCRIPTION
## Summary
- add claude-screenwriting to the Framework Extensions table
- include stars badge and concise description

## Project
https://github.com/e06084/claude-screenwriting

Made with [Cursor](https://cursor.com)