### PR TITLE
Add NotFair — SEO, Google Ads & Meta Ads skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ English | [简体中文](README-CN.md)
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
+|[NotFair](https://github.com/nowork-studio/NotFair) | ![GitHub Repo stars](https://badgen.net/github/stars/nowork-studio/NotFair) | Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads; connects to Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP | Marketing & ads skills plugin|
 
 ## Guides & Documentation
 


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add **NotFair** (https://github.com/nowork-studio/NotFair), an open-source Claude Code plugin focused on marketing and advertising work. It ships agent skills for SEO/GEO analysis, keyword research, content writing, Google Ads management, and Meta (Facebook/Instagram) Ads — and connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. The project has around ~2.9k stars and is MIT licensed.

I've placed it in the **MCP Servers & Plugins** section since it's built around MCP integrations, and kept the format consistent with the other entries.

Happy to move it to a different section, adjust the description, or trim anything — just let me know.