### PR TITLE
feat: add EGC - persistent memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ English | [简体中文](README-CN.md)
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
 
+|[EGC](https://github.com/Fmarzochi/EGC) | ![GitHub Repo stars](https://badgen.net/github/stars/Fmarzochi/EGC) | Persistent cross-session memory MCP server for Claude Code and 12 other AI coding tools. SQLite-backed state survives context resets. | Persistent memory MCP|
+
 ## Guides & Documentation
 
 |Name|Stars|Description|Notes|


### PR DESCRIPTION
## Summary

- Adds [EGC](https://github.com/Fmarzochi/EGC) to the MCP Servers & Plugins section
- EGC is a persistent cross-session memory MCP server that keeps Claude Code context alive across sessions
- SQLite-backed, works with 13+ AI coding tools including Claude Code
- MIT license, install: `npm install -g @egchq/egc`