### PR TITLE
Add claudebar — Powerline statusline with context/rate-limit monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+| [claudebar](https://github.com/micschr0/claudebar) | ![GitHub Repo stars](https://badgen.net/github/stars/micschr0/claudebar) | Powerline-style statusline for Claude Code — live context usage, rate-limit countdowns, git state, 16 themes, ~30 ms render | Rust CLI + TUI configurator |
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
claudebar is a fast, themeable Powerline-style statusline for Claude Code with live context usage, rate-limit countdowns, inline git state, 16 themes, ~30 ms render time (Rust, ~5× faster than bash), and a TUI configurator. Fits the Monitoring & Analytics section. Repo: https://github.com/micschr0/claudebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)