### PR TITLE
Add ai-meeting-skill

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -69,6 +69,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 
 |名称|Stars|简介|备注|
 |-------|-------|-------|------|
+|[ai-meeting-skill](https://github.com/bin1874/ai-meeting-skill) | ![GitHub Repo stars](https://badgen.net/github/stars/bin1874/ai-meeting-skill) | 面向 Codex 和 Claude 的多 agent AI 会议 skill，支持跨轮会话保持和结构化最终报告 | 多 agent 评审工作流|
 |[code2prompt](https://github.com/mufeedvh/code2prompt) | ![GitHub Repo stars](https://badgen.net/github/stars/mufeedvh/code2prompt) | 将代码库转换为单个 LLM 提示的 CLI 工具 | 代码转提示工具|
 |[kilocode](https://github.com/Kilo-Org/kilocode) | ![GitHub Repo stars](https://badgen.net/github/stars/Kilo-Org/kilocode) | 用于规划、构建和修复代码的开源 AI 编程助手 | 开源 AI 助手|
 |[zen-mcp-server](https://github.com/BeehiveInnovations/zen-mcp-server) | ![GitHub Repo stars](https://badgen.net/github/stars/BeehiveInnovations/zen-mcp-server) | Claude Code + 多个模型协同工作的力量 | MCP 服务器|

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ English | [简体中文](README-CN.md)
 
 |Name|Stars|Description|Notes|
 |-------|-------|-------|------|
+|[ai-meeting-skill](https://github.com/bin1874/ai-meeting-skill) | ![GitHub Repo stars](https://badgen.net/github/stars/bin1874/ai-meeting-skill) | Multi-agent AI meeting skill for Codex and Claude with session-preserving rounds and structured final reports | Multi-agent review workflow|
 |[code2prompt](https://github.com/mufeedvh/code2prompt) | ![GitHub Repo stars](https://badgen.net/github/stars/mufeedvh/code2prompt) | CLI tool to convert codebase into single LLM prompt | Code-to-prompt tool|
 |[kilocode](https://github.com/Kilo-Org/kilocode) | ![GitHub Repo stars](https://badgen.net/github/stars/Kilo-Org/kilocode) | Open Source AI coding assistant for planning, building, and fixing code | Open source AI assistant|
 |[zen-mcp-server](https://github.com/BeehiveInnovations/zen-mcp-server) | ![GitHub Repo stars](https://badgen.net/github/stars/BeehiveInnovations/zen-mcp-server) | The power of Claude Code + multiple models working as one | MCP server|


### PR DESCRIPTION
Adds ai-meeting-skill to the Development Tools & Utilities section in both English and Chinese READMEs.

ai-meeting-skill is a multi-agent review workflow for Codex and Claude with session-preserving rounds and structured final reports.

Validation:
- Ran `git diff --check`.