### PR TITLE
Add aigent-OS to Framework Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [简体中文](README-CN.md)
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
+|[aigent-OS](https://github.com/wrg32786/aigent-os) | ![GitHub Repo stars](https://badgen.net/github/stars/wrg32786/aigent-os) | Open-source AI operating system for Claude Code: persistent Obsidian-vault memory, /open + /close session rhythm, subagents, hooks & daemons | Claude Code OS|
 
 ## MCP Servers & Plugins
 


### PR DESCRIPTION
Adds aigent-OS (persistent Obsidian-vault memory, /open + /close session rhythm, subagents, hooks & daemons) to the Framework Extensions table.
Row format matches existing entries (Name+link | star badge | description | tag).