### PR TITLE
Add OpenAgentRelay to development tools

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -81,6 +81,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery) | ![GitHub Repo stars](https://badgen.net/github/stars/disler/claude-code-hooks-mastery) | 掌握 Claude Code hooks 以实现高级自动化 | Hooks 精通指南|
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Claude Code 通信工具 | 通信工具|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | 通过电子邮件、discord、telegram 远程控制 Claude Code | 远程控制工具|
+|[OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) | ![GitHub Repo stars](https://badgen.net/github/stars/ShakespeareLabs/open-agent-relay) | 将任意本地 Agent 或自动化工具转化为团队可调用的能力 | 可信局域网 Agent 中继 CLI|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Claude code 和 Codex 的零配置代码流 | 零配置工作流|
 
 ## 监控与分析

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery) | ![GitHub Repo stars](https://badgen.net/github/stars/disler/claude-code-hooks-mastery) | Master Claude Code hooks for advanced automation | Hooks mastery guide|
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
+|[OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) | ![GitHub Repo stars](https://badgen.net/github/stars/ShakespeareLabs/open-agent-relay) | Turn any local agent or automation into a team-callable capability | Trusted-LAN agent relay CLI|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
 
 ## Monitoring & Analytics


### PR DESCRIPTION
Adds OpenAgentRelay to **Development Tools & Utilities** in both the English and Simplified Chinese lists.\n\nOpenAgentRelay turns a restricted local agent or automation into a team-callable capability over a trusted LAN while keeping the publisher's source, prompts, dependencies, and credentials local.\n\nBoth entries follow the existing four-column table and dynamic star-badge format.