### PR TITLE
Add cc-context-telemetry (statusline wrapper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[cc-context-telemetry](https://github.com/alagiz/cc-context-telemetry) | ![GitHub Repo stars](https://badgen.net/github/stars/alagiz/cc-context-telemetry) | Pure-shell statusline wrapper showing context-window usage, 5h and 7d rate-limit percentages with reset countdowns, and the active model | Statusline telemetry|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
Adds cc-context-telemetry: a zero-dependency, pure-shell Claude Code statusLine wrapper that prepends context-window usage, 5h and 7d rate-limit percentages with reset countdowns, and the active model to your existing statusline, and writes per-session telemetry that hooks can read. MIT.