### PR TITLE
Add PocketAI (native iOS client) to GUI & Web Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-chat](https://github.com/andrepimenta/claude-code-chat) | ![GitHub Repo stars](https://badgen.net/github/stars/andrepimenta/claude-code-chat) | Beautiful Claude Code Chat Interface for VS Code | VS Code chat interface|
 |[Claude-Code-Web-GUI](https://github.com/binggg/Claude-Code-Web-GUI) | ![GitHub Repo stars](https://badgen.net/github/stars/binggg/Claude-Code-Web-GUI) | Browse and view Claude Code session history in browser | Session history viewer|
 |[opcode](https://github.com/winfunc/opcode) | ![GitHub Repo stars](https://badgen.net/github/stars/winfunc/opcode) | Powerful GUI app and Toolkit for Claude Code with custom agents and interactive sessions | Advanced GUI toolkit|
+|[PocketAI](https://apps.apple.com/us/app/pocketai-remote-coding-agent/id6787897526) | - | Native iOS app for driving the Claude Code on your own computer from anywhere — permission prompts as tappable cards with diff previews, works over cellular via encrypted relay, auth-agnostic (subscription / API key / gateway) | Native iOS client|
 
 ## IDE & Editor Extensions
 


### PR DESCRIPTION
添加 **PocketAI** 到 GUI & Web Interfaces。

PocketAI 是 iPhone 原生 App,用于随时随地远程操控自己电脑上的 Claude Code(macOS / Windows·WSL / Linux):

- 权限确认渲染为可点选卡片,Edit/Write 带红绿 diff 预览
- 流式输出 + 思考块 + 工具卡片 + Markdown 原生渲染
- 手机与电脑均为出站连接(加密中继),蜂窝网络可用,无需端口转发/VPN;国内网络直连可用
- 多台电脑、多会话;手机断开后会话在电脑上继续运行
- 不挑登录方式:订阅 / API key / 网关(ANTHROPIC_BASE_URL)均可——官方 Remote Control 不支持的场景
- 有免费层

App Store: https://apps.apple.com/us/app/pocketai-remote-coding-agent/id6787897526

利益相关:我是开发者。条目已按表格现有格式填写(闭源 App 无星数,Stars 列为 -),如格式或措辞需调整请直说。