### PR TITLE
Add WaitPerk to Development Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[WaitPerk](https://github.com/sammpentz-commits/waitperk-client) | ![GitHub Repo stars](https://badgen.net/github/stars/sammpentz-commits/waitperk-client) | Sponsor line in the Claude Code status bar that pays developers for verified on-screen time | Status line monetization|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
Adds [WaitPerk](https://github.com/sammpentz-commits/waitperk-client), a sponsored status line for Claude Code: one sponsor message renders in the status bar and developers are paid for the verified time it is on screen (sponsor payments split 50/50 with the developer pool). The client is a single-file, stdlib-only Python script with Ed25519-signed self-updates, published source-available for auditability. Live at [waitperk.com](https://waitperk.com).

I'm the author. Happy to adjust wording or placement.