### PR TITLE
Add dsx to Development Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[dsx](https://github.com/somework/dsx) | ![GitHub Repo stars](https://badgen.net/github/stars/somework/dsx) | git-style sync (clone/pull/push/status/diff) between a Claude Design project and a local directory, without file bytes passing through a model's context | Claude Design sync|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
Adds **dsx** to *Development Tools & Utilities*, alongside the other local-first CLIs there (ccusage, code2prompt).

dsx is a git-style CLI for the files inside a Claude Design project — `clone` / `pull` / `push` / `status` / `diff` / `fetch`. It moves those files to a local directory and back **without the bytes passing through a model's context**, so a pull that would cost an agent a lot of tokens to read file-by-file costs dsx one summary line.

- reads Claude Code's existing OAuth token (one-time `/design consent`) — no separate login, nothing to wire up as an MCP server
- single Go binary, standard library only, zero dependencies; macOS + Linux, amd64 + arm64; MIT

Repo: https://github.com/somework/dsx