### PR TITLE
Add claude-retro to Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[claude-retro](https://github.com/syahra712/claude-retro) | ![GitHub Repo stars](https://badgen.net/github/stars/syahra712/claude-retro) | Mines local Claude Code transcripts for recurring errors and drafts CLAUDE.md fixes | Local-only retrospective tool|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
Adds [claude-retro](https://github.com/syahra712/claude-retro), a zero-dependency CLI that mines local Claude Code session transcripts for recurring tool errors, permission denials, and corrections, then drafts CLAUDE.md and settings fixes. 100% local, no network calls, no runtime dependencies.