### PR TITLE
Add dev-report to Development Tools & Utilities

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -82,6 +82,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Claude Code 通信工具 | 通信工具|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | 通过电子邮件、discord、telegram 远程控制 Claude Code | 远程控制工具|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Claude code 和 Codex 的零配置代码流 | 零配置工作流|
+|[dev-report](https://github.com/delpicorp/dev-report) | ![GitHub Repo stars](https://badgen.net/github/stars/delpicorp/dev-report) | 用通俗语言解释 Claude Code 会话：改了什么、为什么这样改、还有什么没做完、接下来该做什么 | 会话解释插件|
 
 ## 监控与分析
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[dev-report](https://github.com/delpicorp/dev-report) | ![GitHub Repo stars](https://badgen.net/github/stars/delpicorp/dev-report) | Explains a Claude Code session in plain language: what changed, why that approach, what is still unfinished, and what to do next | Session explanation plugin|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
Adds [dev-report](https://github.com/delpicorp/dev-report) as an external link, matching the other entries in that section. The skill lives in its own repository.

### What it does

You finish a long Claude Code session. A dozen files changed and several implementation decisions were made along the way, but the end-of-session summary is file names and function names — accurate, and written for someone reading the diff alongside it. Asking for it "simply" removes the reasoning too.

`/dev-report` explains the session in plain language instead: what was built or changed, why that approach was chosen, what is still unfinished or unverified, and what to do next.

Technical terms aren't stripped out — they're explained the moment they first appear, so the reasoning survives. Two rules do most of the work: every finding leads with the raw artifact (the actual log line, the actual count) before it gets explained, and the section on how a problem was solved has to name the option that was rejected and what would have gone wrong.

### Details

```
/plugin marketplace add delpicorp/dev-report
/plugin install dev-report@delpicorp
```

- Single skill — no agents, hooks, or MCP servers. About 380 always-on tokens.
- Explicit-only, so it does not fire on a casual "what did you just do?"
- Reports come out in whatever language the command was typed in. Aliases ship for Korean (`/개발보고`), Japanese (`/開発報告`), and Spanish (`/informe-desarrollo`). File paths, function names, and log lines always stay in their original form.
- Two worked example reports ship in the repo (illustrative, not real customer sessions).
- MIT licensed. Disclosure: I'm the author.

Happy to reword or move the entry if it fits better elsewhere.
