### PR TITLE
Add ouroboros to Framework Extensions

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -125,6 +125,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code 超能力：核心技能库 | 核心技能库|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Claude Code 的专业 AI 子代理集合 | 专业子代理|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | 用于 Claude Code 的自定义子代理 | 自定义子代理|
+|[ouroboros](https://github.com/Q00/ouroboros) | ![GitHub Repo stars](https://badgen.net/github/stars/Q00/ouroboros) | 本地优先的 Agent OS，把 Claude Code 等 CLI 代理包装成可回放的 Seed → Ledger → Runtime 工作流（访谈 → Seed → 执行 → 评估 → 进化） | 规格驱动的代理编排|
 
 ## MCP服务器与插件
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [简体中文](README-CN.md)
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
+|[ouroboros](https://github.com/Q00/ouroboros) | ![GitHub Repo stars](https://badgen.net/github/stars/Q00/ouroboros) | Local-first Agent OS that wraps Claude Code and other CLI agents in a replayable Seed → Ledger → Runtime workflow (interview → seed → execute → evaluate → evolve) | Spec-first agent orchestration|
 
 ## MCP Servers & Plugins
 


### PR DESCRIPTION
Adds [Q00/ouroboros](https://github.com/Q00/ouroboros) to Framework Extensions in both README.md and README-CN.md.

Ouroboros is a local-first Agent OS for spec-first AI coding: it wraps Claude Code, Codex CLI, OpenCode, Gemini, and other CLI agents in a replayable interview → seed → execute → evaluate → evolve workflow, recording every action as a Seed-bound, ledger-tracked event. MIT licensed, `pip install ouroboros-ai`.

Disclosure: this PR was opened by an AI coding agent on behalf of the repo owner (@Q00).