### PR TITLE
Add easel (local review boards for agent output)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[easel](https://github.com/The-Sentience-Company/easel) | ![GitHub Repo stars](https://badgen.net/github/stars/The-Sentience-Company/easel) | Local review boards for agent output: the agent publishes plans, evals, and design docs as interactive pages and gets annotations back as structured feedback | Review boards tool|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
Adds [easel](https://github.com/The-Sentience-Company/easel) to Development Tools & Utilities — an open-source (GPLv3) local review layer for Claude Code: the agent publishes plans, evals, and design docs as interactive local pages, blocks on `easel await`, and receives annotations and widget clicks back as structured feedback. Entry follows the existing table format. (I'm the author.)