### PR TITLE
Add pokemanion — a Pokémon that shows when Claude Code is working

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[pokemanion](https://github.com/khatriadbhut/pokemanion) | ![GitHub Repo stars](https://badgen.net/github/stars/khatriadbhut/pokemanion) | A Pokemon in a terminal pane beside every Claude Code session, resting while Claude waits and animating while it works | macOS + Ghostty|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
Adds **[pokemanion](https://github.com/khatriadbhut/pokemanion)** to *Development Tools & Utilities*.

### What it is

An ambient status indicator for Claude Code. A Pokémon sits in a terminal split beside the session — it rests while Claude is waiting on you, and animates while Claude is working. You can tell what state a session is in from across the room, without reading the screen.

- 14 Pokémon ship with it; **1252 more** can be summoned by name (`--gengar`, `--random`)
- A built-in **Pokédex** (`--dex pikachu`, `--dex random`) that draws stats beside the sprite
- Typing `--squirtle` at Claude switches the current pane — handled by a `UserPromptSubmit` hook, so it costs no turn and no tokens
- **Zero dependencies**, plain Node, MIT licensed
- Sprites are credited in `ATTRIBUTION.md`; there's a one-click issue form for artists who want theirs removed

The interesting part is underneath the sprites: Claude Code has no hook for pressing escape, so "is it actually busy?" has to be inferred from the session transcript. That, and the rest of the hook behaviour it depends on, is written up in [`docs/design.md`](https://github.com/khatriadbhut/pokemanion/blob/main/docs/design.md).

### Platform

**macOS + Ghostty only**, and the Notes column says so. It needs the kitty graphics protocol to draw sprites in a terminal cell, and it uses AppleScript to open the split. That limitation is stated plainly at the top of the README too, so nobody arrives expecting Linux support.

### Checklist

- [x] Added to a single existing section, no new sections
- [x] Matches the four-column row format exactly (Name / Stars / Description / Notes)
- [x] Badge URL verified (returns 200)
- [x] One line changed, nothing else touched
