### PR TITLE
Add agent-qa to development tools

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -69,6 +69,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 
 |名称|Stars|简介|备注|
 |-------|-------|-------|------|
+|[agent-qa](https://github.com/vostride/agent-qa) | ![GitHub Repo stars](https://badgen.net/github/stars/vostride/agent-qa) | 开源自我改进 QA 代理，通过 CLI、MCP 和 Claude Code Skills 运行自然语言 Web 与移动端测试 | AI 测试自动化|
 |[code2prompt](https://github.com/mufeedvh/code2prompt) | ![GitHub Repo stars](https://badgen.net/github/stars/mufeedvh/code2prompt) | 将代码库转换为单个 LLM 提示的 CLI 工具 | 代码转提示工具|
 |[kilocode](https://github.com/Kilo-Org/kilocode) | ![GitHub Repo stars](https://badgen.net/github/stars/Kilo-Org/kilocode) | 用于规划、构建和修复代码的开源 AI 编程助手 | 开源 AI 助手|
 |[zen-mcp-server](https://github.com/BeehiveInnovations/zen-mcp-server) | ![GitHub Repo stars](https://badgen.net/github/stars/BeehiveInnovations/zen-mcp-server) | Claude Code + 多个模型协同工作的力量 | MCP 服务器|

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ English | [简体中文](README-CN.md)
 
 |Name|Stars|Description|Notes|
 |-------|-------|-------|------|
+|[agent-qa](https://github.com/vostride/agent-qa) | ![GitHub Repo stars](https://badgen.net/github/stars/vostride/agent-qa) | Open-source self-improving QA agent for natural-language web and mobile tests with CLI, MCP, and Claude Code skills | AI-powered test automation|
 |[code2prompt](https://github.com/mufeedvh/code2prompt) | ![GitHub Repo stars](https://badgen.net/github/stars/mufeedvh/code2prompt) | CLI tool to convert codebase into single LLM prompt | Code-to-prompt tool|
 |[kilocode](https://github.com/Kilo-Org/kilocode) | ![GitHub Repo stars](https://badgen.net/github/stars/Kilo-Org/kilocode) | Open Source AI coding assistant for planning, building, and fixing code | Open source AI assistant|
 |[zen-mcp-server](https://github.com/BeehiveInnovations/zen-mcp-server) | ![GitHub Repo stars](https://badgen.net/github/stars/BeehiveInnovations/zen-mcp-server) | The power of Claude Code + multiple models working as one | MCP server|


### PR DESCRIPTION
## Summary

Adds agent-qa to the Development Tools tables in both the English and Chinese READMEs.

agent-qa is a self-improving QA agent for natural-language web and mobile tests. Its CLI, MCP integration, and three bundled Claude Code-compatible skills cover test authoring, failure triage, and evidence-based debugging.

## Validation

- Preserved the existing four-column table format in both languages.
- Added a dynamic GitHub stars badge using the list's existing badge provider.
- Verified the repository and badge URLs.
- `git diff --check` passes.

Project disclosure: this submission is for agent-qa itself.
