### PR TITLE
Add claude-code-account-switcher (Development Tools & Utilities)

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -82,6 +82,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Claude Code 通信工具 | 通信工具|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | 通过电子邮件、discord、telegram 远程控制 Claude Code | 远程控制工具|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Claude code 和 Codex 的零配置代码流 | 零配置工作流|
+|[claude-code-account-switcher](https://github.com/Nemo-Illusionist/claude-code-account-switcher) | ![GitHub Repo stars](https://badgen.net/github/stars/Nemo-Illusionist/claude-code-account-switcher) | 将 Claude Code 账号绑定到目录 —— `cd` 时通过 `CLAUDE_CONFIG_DIR` 自动激活对应账号，支持按账号的独立配置、IDE 包装器、用量查看与身份审计 | 多账号切换工具|
 
 ## 监控与分析
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[claude-code-account-switcher](https://github.com/Nemo-Illusionist/claude-code-account-switcher) | ![GitHub Repo stars](https://badgen.net/github/stars/Nemo-Illusionist/claude-code-account-switcher) | Binds Claude Code accounts to directories — `cd` activates the matching account via `CLAUDE_CONFIG_DIR`, with per-account settings, IDE wrapper, usage and identity audit | Multi-account switcher|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
Adds one row to **Development Tools & Utilities** in both `README.md` and `README-CN.md`.

[claude-code-account-switcher](https://github.com/Nemo-Illusionist/claude-code-account-switcher) binds Claude Code accounts to directories instead of switching one globally active login. A shell hook resolves the current directory against a bindings file (walking up the tree, so linking `~/work` covers everything under it) and sets `CLAUDE_CONFIG_DIR`, so plain `claude` — and IDE launches, via a wrapper on `PATH` — start under the right account, and different terminals can run different accounts in parallel.

Includes per-account settings/CLAUDE.md/agents, `usage` (5h/7d rate-limit windows per account), a status line with the active account, `doctor` (audits which identity each config dir actually resolves to), and `import` (adopt an existing config dir without a re-login).

Rust CLI with prebuilt macOS/Linux/Windows binaries plus a single-file zsh variant. MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)