### PR TITLE
Add CommitLore

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ English | [简体中文](README-CN.md)
 |[claude_code-gemini-mcp](https://github.com/RaiAnsar/claude_code-gemini-mcp) | ![GitHub Repo stars](https://badgen.net/github/stars/RaiAnsar/claude_code-gemini-mcp) | Simplified Gemini for Claude Code | Gemini integration|
 |[claude-gemini-mcp-slim](https://github.com/cmdaltctr/claude-gemini-mcp-slim) | ![GitHub Repo stars](https://badgen.net/github/stars/cmdaltctr/claude-gemini-mcp-slim) | Lightweight MCP integration bringing Gemini AI capabilities to Claude Code | Lightweight Gemini integration|
 |[mcp-gemini-assistant](https://github.com/peterkrueck/mcp-gemini-assistant) | ![GitHub Repo stars](https://badgen.net/github/stars/peterkrueck/mcp-gemini-assistant) | MCP Gemini coding assistant for Claude Code | Gemini coding assistant|
+|[commitlore](https://github.com/MongLong0214/commitlore) | ![GitHub Repo stars](https://badgen.net/github/stars/MongLong0214/commitlore) | Git-native decision memory MCP server; stores constraints and ruled-out alternatives as git trailers and refs/notes | Decision memory MCP|
 
 ## Guides & Documentation
 


### PR DESCRIPTION
Adds CommitLore to the MCP Servers & Plugins table. CommitLore is a git-native decision memory MCP server for coding agents that stores constraints and ruled-out alternatives as git trailers and refs/notes.