### PR TITLE
Add viberank to Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[viberank](https://github.com/sculptdotfun/viberank) | ![GitHub Repo stars](https://badgen.net/github/stars/sculptdotfun/viberank) | Public leaderboard and open dataset for AI coding usage across Claude Code, Codex, Gemini CLI, Copilot and OpenCode | Community leaderboard, free JSON API|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
Adds one row to **Monitoring & Analytics**, matching the existing table format (name, badgen stars, description, notes).

The section already lists local dashboards and cost trackers that read Claude Code's JSONL — `Claude-Code-Usage-Monitor`, `sniffly`, `claude-code-costs`, `cctrace`. viberank sits downstream: same underlying ccusage data, aggregated into a public leaderboard rather than a local view, and covering Codex, Gemini CLI, Copilot and OpenCode alongside Claude Code.

1,126 developers and ~$10.9M in API-equivalent spend tracked. MIT licensed, on npm as `viberank-cli`, and listed on ccusage's own community projects page.

**Disclosure: I maintain viberank.** Happy for the wording to be trimmed or the entry dropped.
