### PR TITLE
Add sol-simplify project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[sol-simplify](https://github.com/MongLong0214/sol-simplify) | ![GitHub Repo stars](https://badgen.net/github/stars/MongLong0214/sol-simplify) | One-markdown-file skill for Claude Code and Codex that stops agents from inventing bureaucracy around their own work | Anti-ceremony skill|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
Adds sol-simplify, a one-markdown-file Claude Code/Codex skill that stops agents from inventing bureaucracy (approval gates, governance docs) around their own work, with benchmark numbers cited to raw output.