### PR TITLE
feat: add agent-operator-score

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[agent-operator-score](https://github.com/MongLong0214/agent-operator-score) | ![GitHub Repo stars](https://badgen.net/github/stars/MongLong0214/agent-operator-score) | Scores how well you operate Claude Code, Codex, and Grok CLI from your own session transcripts, plus a controlled-run assessment suite | Operator self-assessment CLI|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
Local-first CLI that scores how well a person operates Claude Code, Codex, and Grok CLI sessions from their own transcripts, plus a controlled-run assessment suite. No model calls in review mode, nothing uploaded.